### PR TITLE
#260 [Fix] JWT Token 재발급이 안되는 오류 수정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,3 @@
 *.jpeg binary
 *.gif binary
 *.bat text merge=union eol=crlf
-출처: https://yeongchan1228.tistory.com/129 [Dev-Logs:티스토리]

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
@@ -2,8 +2,6 @@ package com.daruda.darudaserver.domain.user.controller;
 
 import static com.daruda.darudaserver.global.error.code.SuccessCode.*;
 
-import java.io.IOException;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -26,7 +24,6 @@ import com.daruda.darudaserver.global.auth.UserId;
 import com.daruda.darudaserver.global.common.response.ApiResponse;
 import com.daruda.darudaserver.global.error.code.SuccessCode;
 
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +44,7 @@ public class KakaoController {
 	private String redirectUri;
 
 	@GetMapping("/kakao/login-url")
-	public ResponseEntity<ApiResponse<String>> requestLogin(HttpServletResponse response) throws IOException {
+	public ResponseEntity<ApiResponse<String>> requestLogin() {
 		String location =
 			"https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=" + clientId + "&redirect_uri="
 				+ redirectUri;

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
@@ -85,8 +85,8 @@ public class KakaoController {
 	}
 
 	@PostMapping("/reissue")
-	public ResponseEntity<ApiResponse<JwtTokenResponse>> regenerateToken(@UserId Long userId) {
-		JwtTokenResponse jwtTokenResponse = userService.reissueToken(userId);
+	public ResponseEntity<ApiResponse<JwtTokenResponse>> regenerateToken(@RequestParam("refreshToken") String refreshToken) {
+		JwtTokenResponse jwtTokenResponse = userService.reissueToken(refreshToken);
 		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(jwtTokenResponse, SuccessCode.SUCCESS_REISSUE));
 	}
 
@@ -95,5 +95,4 @@ public class KakaoController {
 		userService.withdrawMe(userId);
 		return ResponseEntity.ok(ApiResponse.ofSuccess(SuccessCode.SUCCESS_WITHDRAW));
 	}
-
 }

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
@@ -85,7 +85,8 @@ public class KakaoController {
 	}
 
 	@PostMapping("/reissue")
-	public ResponseEntity<ApiResponse<JwtTokenResponse>> regenerateToken(@RequestParam("refreshToken") String refreshToken) {
+	public ResponseEntity<ApiResponse<JwtTokenResponse>> regenerateToken(
+		@RequestParam("refreshToken") String refreshToken) {
 		JwtTokenResponse jwtTokenResponse = userService.reissueToken(refreshToken);
 		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(jwtTokenResponse, SuccessCode.SUCCESS_REISSUE));
 	}

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/KakaoController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.daruda.darudaserver.domain.user.dto.request.ReissueTokenRequest;
 import com.daruda.darudaserver.domain.user.dto.request.SignUpRequest;
 import com.daruda.darudaserver.domain.user.dto.response.JwtTokenResponse;
 import com.daruda.darudaserver.domain.user.dto.response.LoginResponse;
@@ -82,9 +83,8 @@ public class KakaoController {
 	}
 
 	@PostMapping("/reissue")
-	public ResponseEntity<ApiResponse<JwtTokenResponse>> regenerateToken(
-		@RequestParam("refreshToken") String refreshToken) {
-		JwtTokenResponse jwtTokenResponse = userService.reissueToken(refreshToken);
+	public ResponseEntity<ApiResponse<JwtTokenResponse>> regenerateToken(@RequestBody ReissueTokenRequest request) {
+		JwtTokenResponse jwtTokenResponse = userService.reissueToken(request.refreshToken());
 		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(jwtTokenResponse, SuccessCode.SUCCESS_REISSUE));
 	}
 

--- a/src/main/java/com/daruda/darudaserver/domain/user/dto/request/ReissueTokenRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/dto/request/ReissueTokenRequest.java
@@ -1,0 +1,6 @@
+package com.daruda.darudaserver.domain.user.dto.request;
+
+public record ReissueTokenRequest(
+	String refreshToken
+) {
+}

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/KakaoService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/KakaoService.java
@@ -34,7 +34,7 @@ public class KakaoService {
 			KakaoTokenResponse kakaoTokenResponse = kakaoAPiFeignClient.getAccessToken(
 				"authorization_code",
 				clientId,
-				"https://daruda.site/api/v1/users/kakao/login-url",
+				redirectUri,
 				code,
 				"application/x-www-form-urlencoded;charset=utf-8"
 			);

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
@@ -69,7 +69,7 @@ public class UserService {
 			String accessToken = jwtTokenProvider.generateAccessToken(userAuthentication);
 			String refreshToken = tokenService.updateRefreshTokenByUserId(userId);
 			log.info("토큰을 정상적으로 생성하였습니다");
-			tokenService.saveRefreshtoken(userId, refreshToken);
+			tokenService.saveRefreshToken(userId, refreshToken);
 			JwtTokenResponse jwtTokenResponse = JwtTokenResponse.builder()
 				.accessToken(accessToken)
 				.refreshToken(refreshToken)
@@ -95,7 +95,7 @@ public class UserService {
 		String accessToken = jwtTokenProvider.generateAccessToken(userAuthentication);
 		String refreshToken = jwtTokenProvider.generateRefreshToken(userAuthentication);
 		log.info("토큰을 정상적으로 생성하였습니다");
-		tokenService.saveRefreshtoken(userId, refreshToken);
+		tokenService.saveRefreshToken(userId, refreshToken);
 
 		JwtTokenResponse jwtTokenResponse = JwtTokenResponse.of(accessToken, refreshToken);
 
@@ -127,7 +127,7 @@ public class UserService {
 
 		String newRefreshToken = jwtTokenProvider.generateRefreshToken(userAuthentication);
 		log.debug("RefreshToken을 정상적으로 생성하였습니다, {}", newRefreshToken);
-		tokenService.saveRefreshtoken(userId, newRefreshToken);
+		tokenService.saveRefreshToken(userId, newRefreshToken);
 
 		return JwtTokenResponse.builder()
 			.accessToken(newAccessToken)

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/UserService.java
@@ -26,12 +26,14 @@ import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import com.daruda.darudaserver.domain.user.entity.enums.Positions;
 import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.auth.jwt.provider.JwtTokenProvider;
+import com.daruda.darudaserver.global.auth.jwt.provider.JwtValidationType;
 import com.daruda.darudaserver.global.auth.jwt.service.TokenService;
 import com.daruda.darudaserver.global.auth.security.UserAuthentication;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.BadRequestException;
 import com.daruda.darudaserver.global.error.exception.BusinessException;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
+import com.daruda.darudaserver.global.error.exception.UnauthorizedException;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -109,25 +111,28 @@ public class UserService {
 		return userRepository.existsByNickname(nickname);
 	}
 
-	public JwtTokenResponse reissueToken(Long userId) {
-		String requestToken = tokenService.getRefreshTokenByUserId(userId);
-		log.debug("RefreshToken을 성공적으로 조회하였습니다, {}", requestToken);
-		UserEntity userEntity = userRepository.findById(userId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-		verifyUserIdWithStoredToken(userId, requestToken);
+	@Transactional
+	public JwtTokenResponse reissueToken(String refreshToken) {
+		validateRefreshToken(refreshToken);
+
+		Long userId = jwtTokenProvider.getUserIdFromJwt(refreshToken);
+
+		verifyUserIdWithStoredToken(userId, refreshToken);
 
 		UserAuthentication userAuthentication = UserAuthentication.createUserAuthentication(userId);
 
 		//새 토큰 생성
-		String accessToken = jwtTokenProvider.generateAccessToken(userAuthentication);
-		log.debug("토큰을 정상적으로 생성하였습니다, {}", accessToken);
+		String newAccessToken = jwtTokenProvider.generateAccessToken(userAuthentication);
+		log.debug("AccessToken을 정상적으로 생성하였습니다, {}", newAccessToken);
 
-		JwtTokenResponse jwtTokenResponse = JwtTokenResponse.builder()
-			.accessToken(accessToken)
-			.refreshToken(requestToken)
+		String newRefreshToken = jwtTokenProvider.generateRefreshToken(userAuthentication);
+		log.debug("RefreshToken을 정상적으로 생성하였습니다, {}", newRefreshToken);
+		tokenService.saveRefreshtoken(userId, newRefreshToken);
+
+		return JwtTokenResponse.builder()
+			.accessToken(newAccessToken)
+			.refreshToken(newRefreshToken)
 			.build();
-		return jwtTokenResponse;
-
 	}
 
 	public MyProfileResponse getMyInfo(Long userId) {
@@ -222,6 +227,21 @@ public class UserService {
 		//토큰 삭제
 		tokenService.deleteRefreshToken(userId);
 		log.info("Refresh 토큰을 정상적으로 삭제하였습니다");
+	}
+
+	private void validateRefreshToken(String refreshToken) {
+		JwtValidationType validationType = jwtTokenProvider.validateToken(refreshToken);
+
+		if (!validationType.equals(JwtValidationType.VALID_JWT)) {
+			throw switch (validationType) {
+				case EXPIRED_JWT_TOKEN -> new UnauthorizedException(ErrorCode.REFRESH_TOKEN_EXPIRED_ERROR);
+				case INVALID_JWT_TOKEN -> new BadRequestException(ErrorCode.INVALID_REFRESH_TOKEN_ERROR);
+				case INVALID_JWT_SIGNATURE -> new BadRequestException(ErrorCode.REFRESH_TOKEN_SIGNATURE_ERROR);
+				case UNSUPPORTED_JWT_TOKEN -> new BadRequestException(ErrorCode.UNSUPPORTED_REFRESH_TOKEN_ERROR);
+				case EMPTY_JWT -> new BadRequestException(ErrorCode.REFRESH_TOKEN_EMPTY_ERROR);
+				default -> new BusinessException(ErrorCode.UNKNOWN_REFRESH_TOKEN_ERROR);
+			};
+		}
 	}
 
 	private void verifyUserIdWithStoredToken(final Long userId, final String refreshToken) {

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
@@ -22,7 +22,7 @@ public class TokenService {
 	private final JwtTokenProvider jwtTokenProvider;
 
 	@Transactional
-	public void saveRefreshtoken(final Long userId, final String refreshToken) {
+	public void saveRefreshToken(final Long userId, final String refreshToken) {
 		tokenRepository.findByUserId(userId).ifPresent(tokenRepository::delete);
 
 		tokenRepository.save(Token.builder()

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
@@ -46,13 +46,6 @@ public class TokenService {
 		tokenRepository.delete(token);
 	}
 
-	@Transactional
-	public String getRefreshTokenByUserId(Long userId) {
-		Token token = tokenRepository.findByUserId(userId)
-			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
-		return token.getRefreshToken();
-	}
-
 	public String updateRefreshTokenByUserId(Long userId) {
 		tokenRepository.findByUserId(userId).ifPresent(tokenRepository::delete);
 

--- a/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/jwt/service/TokenService.java
@@ -23,6 +23,8 @@ public class TokenService {
 
 	@Transactional
 	public void saveRefreshtoken(final Long userId, final String refreshToken) {
+		tokenRepository.findByUserId(userId).ifPresent(tokenRepository::delete);
+
 		tokenRepository.save(Token.builder()
 			.userId(userId)
 			.refreshToken(refreshToken)

--- a/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
 	FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500002", "이미지 업로드에 실패했습니다"),
 	FILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "E500003", "이미지를 찾을 수 없습니다"),
 	FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500004", "이미지 삭제에 실패했습니다"),
-	UNKNOWN_REFRESH_TOKEN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"E500005", "알 수 없는 리프레쉬 토큰 오류가 발생했습니다");
+	UNKNOWN_REFRESH_TOKEN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500005", "알 수 없는 리프레쉬 토큰 오류가 발생했습니다");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
@@ -51,7 +51,8 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001", "서버 내부에서 오류가 발생했습니다"),
 	FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500002", "이미지 업로드에 실패했습니다"),
 	FILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "E500003", "이미지를 찾을 수 없습니다"),
-	FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500004", "이미지 삭제에 실패했습니다");
+	FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "E500004", "이미지 삭제에 실패했습니다"),
+	UNKNOWN_REFRESH_TOKEN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"E500005", "알 수 없는 리프레쉬 토큰 오류가 발생했습니다");
 
 	private final HttpStatus httpStatus;
 	private final String code;


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #260

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- [x] JWT Token 재발급이 안되는 오류 수정
- [x] Kakao OAuth Redirect Uri 하드코딩 학제 

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
저희가 현재 DB에 리프레시 토큰을 저장하고 있는데, 추후에 해당 테이블을 삭제하고 Redis에 저장하는 방식으로 변경하고자 합니다.

## 📬 Postman
- Postman 대신에 Swagger 테스트 이미지를 첨부합니다.
![image](https://github.com/user-attachments/assets/88cb7b2e-1ac4-4522-ab7b-ba679ab4f2e0)

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed extraneous repository configuration comments.
- **Refactor**
	- Streamlined social login and token refresh processes by updating endpoint parameters and adopting dynamic redirection for improved flexibility.
	- Enhanced token management with robust validation and consistent handling.
- **New Features**
	- Introduced a new record class for reissuing tokens, encapsulating the refresh token value.
- **Bug Fixes**
	- Improved error messaging for refresh token issues to provide clearer feedback during authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->