### PR TITLE
#264 [Fix] API 엔드포인트 오탈자 수정

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -60,7 +60,7 @@ public class CommentController {
 	}
 
 	@DisableSwaggerSecurity
-	@GetMapping("/")
+	@GetMapping
 	@Operation(summary = "댓글 조회", description = "댓글을 조회합니다.")
 	public ResponseEntity<ApiResponse<GetCommentRetrieveResponse>> getComment(
 		@Parameter(description = "board Id", example = "1")

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/AuthController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/AuthController.java
@@ -83,6 +83,7 @@ public class AuthController {
 		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(returnedUserId, SuccessCode.SUCCESS_LOGOUT));
 	}
 
+	@DisableSwaggerSecurity
 	@PostMapping("/reissue")
 	@Operation(summary = "Access Token 재발급", description = "Refresh Token을 통해 Access Token을 재발급합니다.")
 	public ResponseEntity<ApiResponse<JwtTokenResponse>> regenerateToken(@RequestBody ReissueTokenRequest request) {

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/api/v1/user/nickname",
-		"/api/v1/comment/{board-id}",
+		"/api/v1/comment",
 		"/api/v1/auth/sign-up",
 		"/api/v1/auth/login",
 		"/api/v1/auth/login-url",

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -40,6 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/v1/auth/sign-up",
 		"/api/v1/auth/login",
 		"/api/v1/auth/login-url",
+		"/api/v1/auth/reissue",
 		"/api/v1/tool",
 		"/api/v1/tool/{tool-id}",
 		"/api/v1/tool/{tool-id}/plans",

--- a/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
 		"/api/v1/auth/sign-up",
 		"/api/v1/auth/login",
 		"/api/v1/auth/login-url",
+		"/api/v1/auth/reissue",
 		"/api/v1/tool",
 		"/api/v1/tool/{tool-id}",
 		"/api/v1/tool/{tool-id}/plans",

--- a/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/api/v1/user/nickname",
-		"/api/v1/comment/{board-id}",
+		"/api/v1/comment",
 		"/api/v1/auth/sign-up",
 		"/api/v1/auth/login",
 		"/api/v1/auth/login-url",


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #264

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- [x] `/api/v1/comment` API의 엔드포인트 오탈자 수정
- [x] `SecurityConfig`와 `JwtAuthenticationFilter`에 변경 사항 반영

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman
### AS-IS
![image](https://github.com/user-attachments/assets/d99317b5-a941-4bdd-8d1f-cc3cbe42a061)

### TO-BE
![image](https://github.com/user-attachments/assets/e6a59d8e-542a-41d3-896e-4e01a6958c5c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 액세스 토큰을 재생성하는 새로운 API 엔드포인트를 추가했습니다.
  
- **리팩터링**
  - 댓글 API의 접근 경로를 간소화하여 기본 URL로 직접 접속할 수 있도록 개선했습니다.
  - 인증 필터 및 보안 설정을 업데이트하여 변경된 경로에 대해 보다 일관된 접근 환경을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->