### PR TITLE
#269 [Feat] 이미지 로직 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     // Sentry 추가
     implementation 'io.sentry:sentry-logback:7.17.0'
     implementation 'com.github.napstr:logback-discord-appender:1.0.0'
+
+    // 테스트 의존성 추가
+    testImplementation 'org.mockito:mockito-core:5.5.0'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -75,8 +75,8 @@ dependencies {
 
     //aws 추가
     implementation 'software.amazon.awssdk:s3:2.20.45'
-    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.2'
+    
     // Jasypt 추가
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     //aws 추가
     implementation 'software.amazon.awssdk:s3:2.20.45'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.2'
-    
+
     // Jasypt 추가
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
 
     //aws 추가
     implementation 'software.amazon.awssdk:s3:2.20.45'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     // Jasypt 추가
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'

--- a/src/main/java/com/daruda/darudaserver/DarudaApplication.java
+++ b/src/main/java/com/daruda/darudaserver/DarudaApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+import io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration;
+
 @EnableFeignClients
-@SpringBootApplication
 @EnableWebMvc
+@SpringBootApplication(exclude = {S3AutoConfiguration.class})
 public class DarudaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -4,16 +4,7 @@ import java.io.IOException;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.*;
 
 import com.daruda.darudaserver.domain.comment.dto.request.CreateCommentRequest;
 import com.daruda.darudaserver.domain.comment.dto.response.CreateCommentResponse;
@@ -26,7 +17,6 @@ import com.daruda.darudaserver.global.error.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -35,28 +25,22 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/comment")
 @Tag(name = "comment 컨트롤러", description = "댓글과 관련된 API를 처리합니다.")
 public class CommentController {
+
 	private final CommentService commentService;
 
 	@PostMapping
 	@Operation(summary = "댓글 작성", description = "댓글을 작성합니다.")
-	public ResponseEntity<ApiResponse<CreateCommentResponse>> postComment(@AuthenticationPrincipal Long userId,
+	public ResponseEntity<ApiResponse<CreateCommentResponse>> postComment(
+		@AuthenticationPrincipal Long userId,
+
 		@Parameter(description = "board Id", example = "1")
 		@RequestParam("board-id") Long boardId,
-		@Parameter(description = "작성할 댓글")
-		@Valid @ModelAttribute CreateCommentRequest createCommentRequest,
-		@Nullable @RequestPart(value = "image", required = false) MultipartFile image) throws IOException {
-		CreateCommentResponse createCommentResponse = commentService.postComment(userId, boardId, createCommentRequest,
-			image);
-		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(createCommentResponse, SuccessCode.SUCCESS_CREATE));
-	}
 
-	@DeleteMapping("/{comment-id}")
-	@Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
-	public ResponseEntity<ApiResponse<?>> deleteComment(@AuthenticationPrincipal Long userId,
-		@Parameter(description = "comment Id", example = "1")
-		@PathVariable("comment-id") Long commentId) {
-		commentService.deleteComment(userId, commentId);
-		return ResponseEntity.ok(ApiResponse.ofSuccess(SuccessCode.SUCCESS_DELETE));
+		@Parameter(description = "작성할 댓글")
+		@RequestBody @Valid CreateCommentRequest request
+	) {
+		CreateCommentResponse response = commentService.postComment(userId, boardId, request);
+		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(response, SuccessCode.SUCCESS_CREATE));
 	}
 
 	@DisableSwaggerSecurity
@@ -65,11 +49,26 @@ public class CommentController {
 	public ResponseEntity<ApiResponse<GetCommentRetrieveResponse>> getComment(
 		@Parameter(description = "board Id", example = "1")
 		@RequestParam("board-id") Long boardId,
+
 		@Parameter(description = "조회할 댓글 개수", example = "10")
 		@RequestParam(value = "size", defaultValue = "10") int size,
+
 		@Parameter(description = "조회했을 때 마지막 comment Id", example = "10")
-		@RequestParam(value = "lastCommentId", required = false) Long commentId) {
-		GetCommentRetrieveResponse getCommentRetrieveResponse = commentService.getComments(boardId, size, commentId);
-		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(getCommentRetrieveResponse, SuccessCode.SUCCESS_FETCH));
+		@RequestParam(value = "lastCommentId", required = false) Long commentId
+	) {
+		GetCommentRetrieveResponse response = commentService.getComments(boardId, size, commentId);
+		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(response, SuccessCode.SUCCESS_FETCH));
+	}
+
+	@DeleteMapping("/{comment-id}")
+	@Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+	public ResponseEntity<ApiResponse<?>> deleteComment(
+		@AuthenticationPrincipal Long userId,
+
+		@Parameter(description = "comment Id", example = "1")
+		@PathVariable("comment-id") Long commentId
+	) {
+		commentService.deleteComment(userId, commentId);
+		return ResponseEntity.ok(ApiResponse.ofSuccess(SuccessCode.SUCCESS_DELETE));
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -17,6 +17,7 @@ import com.daruda.darudaserver.global.error.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/controller/CommentController.java
@@ -1,10 +1,15 @@
 package com.daruda.darudaserver.domain.comment.controller;
 
-import java.io.IOException;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.daruda.darudaserver.domain.comment.dto.request.CreateCommentRequest;
 import com.daruda.darudaserver.domain.comment.dto.response.CreateCommentResponse;
@@ -17,7 +22,6 @@ import com.daruda.darudaserver.global.error.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
@@ -1,9 +1,20 @@
 package com.daruda.darudaserver.domain.comment.dto.request;
 
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Size;
 
 public record CreateCommentRequest(
+	@Nullable
 	@Size(min = 1, max = 1000, message = "글자 수는 1자 이상 1000자 이하여야 합니다")
-	String content
+	String content,
+
+	@Nullable
+	String photoUrl
 ) {
+	@AssertTrue(message = "content와 photoUrl 중 하나는 반드시 입력해야 합니다.")
+	private boolean isValid() {
+		return (content != null && !content.isBlank()) ||
+			(photoUrl != null && !photoUrl.isBlank());
+	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/request/CreateCommentRequest.java
@@ -14,7 +14,8 @@ public record CreateCommentRequest(
 ) {
 	@AssertTrue(message = "content와 photoUrl 중 하나는 반드시 입력해야 합니다.")
 	private boolean isValid() {
-		return (content != null && !content.isBlank()) ||
+		return (content != null && !content.isBlank())
+			||
 			(photoUrl != null && !photoUrl.isBlank());
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/CreateCommentResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/CreateCommentResponse.java
@@ -10,20 +10,22 @@ import lombok.Builder;
 public record CreateCommentResponse(
 	Long commentId,
 	String content,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
-	Timestamp updatedAt,
 	String image,
-	String nickname
+	String nickname,
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+	Timestamp updatedAt
 ) {
 
-	public static CreateCommentResponse of(Long commentId, String content, Timestamp updatedAt, String image,
-		String nickname) {
+	public static CreateCommentResponse of(
+		Long commentId, String content, Timestamp updatedAt, String image, String nickname
+	) {
 		return CreateCommentResponse.builder()
 			.commentId(commentId)
 			.content(content)
-			.updatedAt(updatedAt)
 			.image(image)
 			.nickname(nickname)
+			.updatedAt(updatedAt)
 			.build();
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/GetCommentResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/GetCommentResponse.java
@@ -12,7 +12,6 @@ public record GetCommentResponse(
 	Long commentId,
 	String nickname,
 	String image,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
 	Timestamp updatedAt
 ) {
 

--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/GetCommentResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/GetCommentResponse.java
@@ -2,8 +2,6 @@ package com.daruda.darudaserver.domain.comment.dto.response;
 
 import java.sql.Timestamp;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/daruda/darudaserver/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/entity/CommentEntity.java
@@ -1,25 +1,35 @@
 package com.daruda.darudaserver.domain.comment.entity;
 
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
 import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
 @Table(name = "comment")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql =
-	"UPDATE comment SET is_deleted = true, deleted_at = NOW() " +
-	"WHERE comment_id = ?")
+	"UPDATE comment SET is_deleted = true, deleted_at = NOW() "
+		+ "WHERE comment_id = ?")
 @SQLRestriction("is_deleted = false")
 public class CommentEntity extends BaseTimeEntity {
 

--- a/src/main/java/com/daruda/darudaserver/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/entity/CommentEntity.java
@@ -3,52 +3,80 @@ package com.daruda.darudaserver.domain.comment.entity;
 import com.daruda.darudaserver.domain.community.entity.Board;
 import com.daruda.darudaserver.domain.user.entity.UserEntity;
 import com.daruda.darudaserver.global.common.entity.BaseTimeEntity;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
 @Table(name = "comment")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@SQLDelete(sql =
+	"UPDATE comment SET is_deleted = true, deleted_at = NOW() " +
+	"WHERE comment_id = ?")
+@SQLRestriction("is_deleted = false")
 public class CommentEntity extends BaseTimeEntity {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "comment_id")
 	private Long id;
 
-	@Column(name = "content", nullable = false)
+	@Column(length = 1_000)
 	private String content;
 
-	@Column(name = "comment_photo_url", nullable = true)
+	@Column(name = "comment_photo_url")
 	private String photoUrl;
 
-	@ManyToOne(targetEntity = UserEntity.class, fetch = FetchType.LAZY)
+	@Column(name = "is_deleted", nullable = false)
+	private boolean isDeleted = false;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private UserEntity user;
 
-	@ManyToOne(targetEntity = Board.class, fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "board_id", nullable = false)
 	private Board board;
 
 	@Builder
-	public CommentEntity(String content, String photoUrl, UserEntity user, Board board) {
+	private CommentEntity(
+		String content, String photoUrl, UserEntity user, Board board
+	) {
 		this.content = content;
 		this.photoUrl = photoUrl;
-		this.board = board;
 		this.user = user;
+		this.board = board;
+
+		this.isDeleted = false;
+		this.deletedAt = null;
+	}
+
+	public static CommentEntity of(
+		String content, String photoUrl, UserEntity user, Board board
+	) {
+		return CommentEntity.builder()
+			.content(content)
+			.photoUrl(photoUrl)
+			.user(user)
+			.board(board)
+			.build();
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
+
+	public void updatePhotoUrl(String photoUrl) {
+		this.photoUrl = photoUrl;
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/repository/CommentRepository.java
@@ -20,19 +20,19 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 		+ "WHERE c.board.id = :boardId "
 		+ "AND c.id < :cursor "
 		+ "ORDER BY c.createdAt DESC")
-	List<CommentEntity> findAllByBoardId(
+	List<CommentEntity> findCommentsByBoardId(
 		@Param("boardId") Long boardId,
 		@Param("cursor") Long cursor,
-		Pageable pageable);
+		Pageable pageable
+	);
 
-	List<CommentEntity> findAllByBoardId(Long boardId);
-
-	@Modifying
-	@Transactional
-	void deleteAllByUserId(@Param("userId") Long userId);
+	List<CommentEntity> findCommentsByBoardId(Long boardId);
 
 	@Modifying
 	@Transactional
-	void deleteByBoardId(@Param("boardId") Long boardId);
+	void deleteCommentsByUserId(@Param("userId") Long userId);
 
+	@Modifying
+	@Transactional
+	void deleteCommentsByBoardId(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
@@ -1,6 +1,5 @@
 package com.daruda.darudaserver.domain.comment.service;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.springframework.data.domain.PageRequest;
@@ -19,8 +18,8 @@ import com.daruda.darudaserver.domain.user.repository.UserRepository;
 import com.daruda.darudaserver.global.common.response.ScrollPaginationCollection;
 import com.daruda.darudaserver.global.common.response.ScrollPaginationDto;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.NotFoundException;
 import com.daruda.darudaserver.global.error.exception.ForbiddenException;
+import com.daruda.darudaserver.global.error.exception.NotFoundException;
 import com.daruda.darudaserver.global.s3.S3Service;
 
 import jakarta.transaction.Transactional;
@@ -92,7 +91,7 @@ public class CommentService {
 
 		long nextCursor = scroll.isLastScroll()   // 마지막 페이지 여부
 			? -1L
-			: scroll.getNextCursor().getId();	// 다음 페이지 커서
+			: scroll.getNextCursor().getId();    // 다음 페이지 커서
 
 		ScrollPaginationDto pageInfo = ScrollPaginationDto.of(items.size(), nextCursor);  // 현재 페이지 건수만 전달
 

--- a/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.daruda.darudaserver.domain.comment.service;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.springframework.data.domain.PageRequest;
@@ -20,6 +21,7 @@ import com.daruda.darudaserver.global.common.response.ScrollPaginationDto;
 import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
 import com.daruda.darudaserver.global.error.exception.ForbiddenException;
+import com.daruda.darudaserver.global.s3.S3Service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,7 @@ public class CommentService {
 	private final CommentRepository commentRepository;
 	private final BoardRepository boardRepository;
 	private final UserRepository userRepository;
+	private final S3Service s3Service;
 
 	public CreateCommentResponse postComment(
 		Long userId, Long boardId, CreateCommentRequest request

--- a/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
@@ -1,7 +1,5 @@
 package com.daruda.darudaserver.domain.community.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -10,11 +8,10 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.daruda.darudaserver.domain.community.dto.req.BoardCreateAndUpdateReq;
 import com.daruda.darudaserver.domain.community.dto.res.BoardRes;
@@ -29,7 +26,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -44,10 +40,9 @@ public class BoardController {
 	public ResponseEntity<ApiResponse<?>> createBoard(
 		@AuthenticationPrincipal Long userId,
 		@Parameter(description = "작성할 게시글")
-		@ModelAttribute @Valid BoardCreateAndUpdateReq boardCreateAndUpdateReq,
-		@RequestPart(value = "images", required = false) @Size(max = 5) List<MultipartFile> images) {
+		@RequestBody @Valid BoardCreateAndUpdateReq boardCreateAndUpdateReq) {
 
-		BoardRes boardRes = boardService.createBoard(userId, boardCreateAndUpdateReq, images);
+		BoardRes boardRes = boardService.createBoard(userId, boardCreateAndUpdateReq);
 		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardRes, SuccessCode.SUCCESS_CREATE));
 	}
 
@@ -58,9 +53,8 @@ public class BoardController {
 		@Parameter(description = "board Id", example = "1")
 		@PathVariable(name = "board-id") final Long boardId,
 		@Parameter(description = "수정할 게시글")
-		@ModelAttribute @Valid final BoardCreateAndUpdateReq boardCreateAndUpdateReq,
-		@RequestPart(value = "images", required = false) @Size(max = 5) List<MultipartFile> images) {
-		BoardRes boardRes = boardService.updateBoard(userId, boardId, boardCreateAndUpdateReq, images);
+		@ModelAttribute @Valid final BoardCreateAndUpdateReq boardCreateAndUpdateReq) {
+		BoardRes boardRes = boardService.updateBoard(userId, boardId, boardCreateAndUpdateReq);
 		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardRes, SuccessCode.SUCCESS_UPDATE));
 	}
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/req/BoardCreateAndUpdateReq.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/req/BoardCreateAndUpdateReq.java
@@ -15,7 +15,7 @@ public record BoardCreateAndUpdateReq(
 	String content,
 	Long toolId,
 	@NotNull(message = "자유 게시판 선택은 필수 입니다")
-	boolean isFree,// 자유 게시판 여부 추가
+	boolean isFree,
 	@NotNull
 	List<String> imageList
 ) {

--- a/src/main/java/com/daruda/darudaserver/domain/community/dto/req/BoardCreateAndUpdateReq.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/dto/req/BoardCreateAndUpdateReq.java
@@ -1,5 +1,7 @@
 package com.daruda.darudaserver.domain.community.dto.req;
 
+import java.util.List;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -13,14 +15,17 @@ public record BoardCreateAndUpdateReq(
 	String content,
 	Long toolId,
 	@NotNull(message = "자유 게시판 선택은 필수 입니다")
-	boolean isFree// 자유 게시판 여부 추가
+	boolean isFree,// 자유 게시판 여부 추가
+	@NotNull
+	List<String> imageList
 ) {
 
-	public static BoardCreateAndUpdateReq of(String title, String content, Long toolId, boolean isFree) {
-		return new BoardCreateAndUpdateReq(title, content, toolId, isFree);
+	public static BoardCreateAndUpdateReq of(String title, String content, Long toolId, boolean isFree,
+		List<String> imageList) {
+		return new BoardCreateAndUpdateReq(title, content, toolId, isFree, imageList);
 	}
 
-	public static BoardCreateAndUpdateReq of(String title, String content, Long toolId) {
-		return new BoardCreateAndUpdateReq(title, content, toolId, true);
+	public static BoardCreateAndUpdateReq of(String title, String content, Long toolId, List<String> imageList) {
+		return new BoardCreateAndUpdateReq(title, content, toolId, true, imageList);
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardImageService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardImageService.java
@@ -30,9 +30,7 @@ public class BoardImageService {
 
 	public List<String> getBoardImageUrls(Long boardId) {
 		return boardImageRepository.findAllByBoardId(boardId).stream()
-			.map(boardImage ->
-				IMAGE_URL + imageService.getImageUrlById(boardImage.getImageId())
-			)
+			.map(boardImage -> imageService.getImageUrlById(boardImage.getImageId()))
 			.toList();
 	}
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -285,7 +285,7 @@ public class BoardService {
 		return board;
 	}
 
-	private List<String> processImages(final Board board, final List<String> images) {
+	public List<String> processImages(final Board board, final List<String> images) {
 		if (images == null || images.isEmpty()) {
 			deleteOriginImages(board.getId());
 			return List.of();
@@ -309,11 +309,11 @@ public class BoardService {
 			.orElseThrow(() -> new NotFoundException(ErrorCode.BOARD_NOT_FOUND));
 	}
 
-	private Tool getToolById(final Long toolId) {
+	public Tool getToolById(final Long toolId) {
 		return toolRepository.findById(toolId).orElseThrow(() -> new NotFoundException(ErrorCode.TOOL_NOT_FOUND));
 	}
 
-	private UserEntity getUserById(final Long userId) {
+	public UserEntity getUserById(final Long userId) {
 		return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 	}
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -309,11 +309,11 @@ public class BoardService {
 			.orElseThrow(() -> new NotFoundException(ErrorCode.BOARD_NOT_FOUND));
 	}
 
-	public Tool getToolById(final Long toolId) {
+	private Tool getToolById(final Long toolId) {
 		return toolRepository.findById(toolId).orElseThrow(() -> new NotFoundException(ErrorCode.TOOL_NOT_FOUND));
 	}
 
-	public UserEntity getUserById(final Long userId) {
+	private UserEntity getUserById(final Long userId) {
 		return userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 	}
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -285,7 +285,7 @@ public class BoardService {
 		return board;
 	}
 
-	public List<String> processImages(final Board board, final List<String> images) {
+	private List<String> processImages(final Board board, final List<String> images) {
 		if (images == null || images.isEmpty()) {
 			deleteOriginImages(board.getId());
 			return List.of();

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -122,7 +122,7 @@ public class BoardService {
 	public void deleteBoard(final Long userId, final Long boardId) {
 		Board board = validateBoardAndUser(userId, boardId);
 		deleteOriginImages(boardId);
-		List<CommentEntity> commentEntityList = commentRepository.findAllByBoardId(boardId);
+		List<CommentEntity> commentEntityList = commentRepository.findCommentsByBoardId(boardId);
 		List<BoardScrap> scraps = boardScrapRepository.findAllByBoardId(boardId);
 		if (!scraps.isEmpty()) {
 			boardScrapRepository.deleteAll(scraps);
@@ -344,7 +344,7 @@ public class BoardService {
 	}
 
 	public int getCommentCount(final Long boardId) {
-		List<CommentEntity> commentEntityList = commentRepository.findAllByBoardId(boardId);
+		List<CommentEntity> commentEntityList = commentRepository.findCommentsByBoardId(boardId);
 		log.debug("댓글 Entity리스트를 받아옵니다 : " + commentEntityList.size());
 		return commentEntityList.size();
 	}

--- a/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/service/BoardService.java
@@ -291,6 +291,12 @@ public class BoardService {
 			return List.of();
 		}
 		deleteOriginImages(board.getId());
+		List<String> validImages = images.stream()
+			.filter(url -> url != null && !url.isBlank())
+			.toList();
+		if (validImages.isEmpty()) {
+			return List.of();
+		}
 		List<Long> imageIds = imageService.createImage(images);
 		boardImageService.saveBoardImages(board.getId(), imageIds);
 		return boardImageService.getBoardImageUrls(board.getId());

--- a/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/tool/controller/ToolController.java
@@ -31,7 +31,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/tool")

--- a/src/main/java/com/daruda/darudaserver/domain/user/service/AuthService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/service/AuthService.java
@@ -89,11 +89,11 @@ public class AuthService {
 		toolScrapRepository.deleteAllByUserId(userId);
 		log.info("toolScrap을 성공적으로 삭제하였습니다");
 
-		commentRepository.deleteAllByUserId(userId);
+		commentRepository.deleteCommentsByUserId(userId);
 
 		List<Board> boardList = boardRepository.findAllByUserId(userId);
 
-		boardList.forEach(board -> commentRepository.deleteByBoardId(board.getId()));
+		boardList.forEach(board -> commentRepository.deleteCommentsByBoardId(board.getId()));
 
 		//FK로 묶여있는 boardScrap 삭제
 		boardScrapRepository.deleteAllByUserId(userId);

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -49,7 +49,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/v1/tool/{tool-id}/alternatives",
 		"/api/v1/tool/category",
 		"/api/v1/board",
-		"/api/v1/image/*",
+		"/api/v1/image/**",
 		"/api/v1/board/{board-id}"
 	);
 
@@ -75,7 +75,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	@Override
-	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+	protected boolean shouldNotFilter(HttpServletRequest request) {
 
 		String path = request.getServletPath();
 		String method = request.getMethod();

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import org.springframework.http.HttpMethod;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
@@ -32,10 +31,12 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+	private final JwtTokenProvider jwtTokenProvider;
 	private static final List<String> EXCLUDE_URL = Arrays.asList(
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/api/v1/user/nickname",
+		"/api/v1/comment",
 		"/api/v1/auth/sign-up",
 		"/api/v1/auth/login",
 		"/api/v1/auth/login-url",
@@ -45,9 +46,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/v1/tool/{tool-id}/plans",
 		"/api/v1/tool/{tool-id}/core-features",
 		"/api/v1/tool/{tool-id}/alternatives",
-		"/api/v1/tool/category"
+		"/api/v1/tool/category",
+		"/api/v1/board",
+		"/api/v1/image/*",
+		"/api/v1/board/{board-id}"
 	);
-	private final JwtTokenProvider jwtTokenProvider;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -71,15 +74,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	@Override
-	protected boolean shouldNotFilter(HttpServletRequest request) {
+	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+
 		String path = request.getServletPath();
 		String method = request.getMethod();
-
-		// GET 요청만 필터 제외
-		if (method.equals(HttpMethod.GET.name())) {
-			return EXCLUDE_URL.stream().anyMatch(exclude -> new AntPathMatcher().match(exclude, path));
-		}
-		return false;
+		//        // GET 요청만 인증 우회
+		//        if (path.startsWith("/api/v1/boards/board/**") && method.equals("GET")) {
+		//            return true;
+		//        }
+		return EXCLUDE_URL.stream().anyMatch(exclude -> new AntPathMatcher().match(exclude, path));
 	}
 
 	private String getAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/security/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
@@ -78,11 +79,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		String path = request.getServletPath();
 		String method = request.getMethod();
-		//        // GET 요청만 인증 우회
-		//        if (path.startsWith("/api/v1/boards/board/**") && method.equals("GET")) {
-		//            return true;
-		//        }
-		return EXCLUDE_URL.stream().anyMatch(exclude -> new AntPathMatcher().match(exclude, path));
+
+		if (method.equals(HttpMethod.GET.name())) {
+			return EXCLUDE_URL.stream().anyMatch(exclude -> new AntPathMatcher().match(exclude, path));
+		}
+		return false;
 	}
 
 	private String getAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
 		"/api/v1/tool/{tool-id}/alternatives",
 		"/api/v1/tool/category",
 		"/api/v1/board",
+		"/api/v1/image/*",
 		"/api/v1/board/{board-id}"
 	};
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;

--- a/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
 		"/api/v1/tool/category",
 		"/api/v1/board",
 		"/api/v1/image/*",
-		"/api/v1/board/{board-id}"
+		"/api/v1/board/{board-id}",
+		"/api/v1/image/presigned-url"
 	};
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 	private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
 		"/api/v1/tool/{tool-id}/alternatives",
 		"/api/v1/tool/category",
 		"/api/v1/board",
-		"/api/v1/image/*",
+		"/api/v1/image/**",
 		"/api/v1/board/{board-id}",
 		"/api/v1/image/presigned-url"
 	};

--- a/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/daruda/darudaserver/global/config/SecurityConfig.java
@@ -66,7 +66,6 @@ public class SecurityConfig {
 
 					.requestMatchers(WHITE_LIST)
 					.permitAll()
-
 					.anyRequest()
 					.authenticated())
 			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/code/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
 
 	/* 403 */
 	BOARD_FORBIDDEN(HttpStatus.FORBIDDEN, "E403001", "게시판 접근 권한이 없습니다."),
+	NO_PERMISSION_TO_DELETE(HttpStatus.FORBIDDEN, "E403002", "삭제 권한이 없습니다."),
 
 	/* 404 NOT FOUND */
 

--- a/src/main/java/com/daruda/darudaserver/global/error/exception/ForbiddenException.java
+++ b/src/main/java/com/daruda/darudaserver/global/error/exception/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.daruda.darudaserver.global.error.exception;
+
+import com.daruda.darudaserver.global.error.code.ErrorCode;
+
+public class ForbiddenException extends BusinessException {
+	public ForbiddenException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}
+

--- a/src/main/java/com/daruda/darudaserver/global/image/controller/ImageController.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/controller/ImageController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.daruda.darudaserver.global.error.code.SuccessCode;
+import com.daruda.darudaserver.global.error.dto.SuccessResponse;
+import com.daruda.darudaserver.global.image.dto.request.GetPresignedUrlRequest;
+import com.daruda.darudaserver.global.image.dto.response.GetPresignedUrlListResponse;
 import com.daruda.darudaserver.global.image.service.ImageService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,4 +42,15 @@ public class ImageController {
 		imageService.deleteImages(imageIds);
 		return ResponseEntity.ok(imageIds);
 	}
+
+	@GetMapping("/presigned-url")
+	@Operation(summary = "이미지 업로드 용 presigned-url발급", description = "이미지 업로드를 위한 presignedUrl을 발급합니다")
+	public ResponseEntity<SuccessResponse<?>> getPresignedUrl(
+		@RequestBody GetPresignedUrlRequest getPresignedUrlRequest) {
+		GetPresignedUrlListResponse getPresignedUrlResponseList = imageService.getUploadPresignedURL(
+			getPresignedUrlRequest);
+
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE, getPresignedUrlResponseList));
+	}
+
 }

--- a/src/main/java/com/daruda/darudaserver/global/image/controller/ImageController.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/controller/ImageController.java
@@ -20,6 +20,7 @@ import com.daruda.darudaserver.global.image.service.ImageService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -46,7 +47,7 @@ public class ImageController {
 	@GetMapping("/presigned-url")
 	@Operation(summary = "이미지 업로드 용 presigned-url발급", description = "이미지 업로드를 위한 presignedUrl을 발급합니다")
 	public ResponseEntity<SuccessResponse<?>> getPresignedUrl(
-		@RequestBody GetPresignedUrlRequest getPresignedUrlRequest) {
+		@Valid @RequestBody GetPresignedUrlRequest getPresignedUrlRequest) {
 		GetPresignedUrlListResponse getPresignedUrlResponseList = imageService.getUploadPresignedURL(
 			getPresignedUrlRequest);
 

--- a/src/main/java/com/daruda/darudaserver/global/image/controller/ImageController.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/controller/ImageController.java
@@ -48,7 +48,7 @@ public class ImageController {
 	@Operation(summary = "이미지 업로드 용 presigned-url발급", description = "이미지 업로드를 위한 presignedUrl을 발급합니다")
 	public ResponseEntity<SuccessResponse<?>> getPresignedUrl(
 		@Valid @RequestBody GetPresignedUrlRequest getPresignedUrlRequest) {
-		GetPresignedUrlListResponse getPresignedUrlResponseList = imageService.getUploadPresignedURL(
+		GetPresignedUrlListResponse getPresignedUrlResponseList = imageService.getUploadPresignedUrl(
 			getPresignedUrlRequest);
 
 		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE, getPresignedUrlResponseList));

--- a/src/main/java/com/daruda/darudaserver/global/image/dto/request/CallBackImageRequest.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/dto/request/CallBackImageRequest.java
@@ -1,0 +1,11 @@
+package com.daruda.darudaserver.global.image.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CallBackImageRequest(
+	@NotNull
+	List<String> imageUrlList
+) {
+}

--- a/src/main/java/com/daruda/darudaserver/global/image/dto/request/GetPresignedUrlRequest.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/dto/request/GetPresignedUrlRequest.java
@@ -1,0 +1,11 @@
+package com.daruda.darudaserver.global.image.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record GetPresignedUrlRequest(
+	@NotNull
+	List<String> keyList
+) {
+}

--- a/src/main/java/com/daruda/darudaserver/global/image/dto/response/GetPresignedUrlListResponse.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/dto/response/GetPresignedUrlListResponse.java
@@ -1,0 +1,11 @@
+package com.daruda.darudaserver.global.image.dto.response;
+
+import java.util.List;
+
+public record GetPresignedUrlListResponse(
+	List<String> presignedUrlList
+) {
+	public static GetPresignedUrlListResponse of(List<String> presignedUrlList) {
+		return new GetPresignedUrlListResponse(presignedUrlList);
+	}
+}

--- a/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
@@ -116,12 +116,16 @@ public class ImageService {
 		List<Long> imageIdList = imageUrlList.stream()
 			.map(
 				imageUrl -> {
-					Image image = Image.builder()
-						.imageUrl(imageUrl)
-						.build();
-					Image savedImage = imageRepository.save(image);
-					log.info("Image saved to database: imageId={}", savedImage.getImageId());
-					return savedImage.getImageId();
+					try {
+						Image image = Image.builder()
+							.imageUrl(imageUrl)
+							.build();
+						Image savedImage = imageRepository.save(image);
+						log.info("Image saved to database: imageId={}", savedImage.getImageId());
+						return savedImage.getImageId();
+					} catch (Exception e) {
+						throw new BusinessException(ErrorCode.FILE_UPLOAD_FAIL);
+					}
 				}
 			)
 			.toList();

--- a/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
@@ -90,7 +90,7 @@ public class ImageService {
 		return getImageById(imageId).getImageUrl();
 	}
 
-	public String createUploadPresignedURL(String key) {
+	public String createUploadPresignedUrl(String key) {
 		PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
 			req -> req.signatureDuration(Duration.ofMinutes(15)) // 유효시간 15분
 				.putObjectRequest(
@@ -103,9 +103,9 @@ public class ImageService {
 		return presignedRequest.url().toString();
 	}
 
-	public GetPresignedUrlListResponse getUploadPresignedURL(GetPresignedUrlRequest getPresignedUrlRequestList) {
+	public GetPresignedUrlListResponse getUploadPresignedUrl(GetPresignedUrlRequest getPresignedUrlRequestList) {
 		List<String> urls = getPresignedUrlRequestList.keyList().stream()
-			.map(this::createUploadPresignedURL)
+			.map(this::createUploadPresignedUrl)
 			.toList();
 
 		return GetPresignedUrlListResponse.of(urls);
@@ -124,6 +124,7 @@ public class ImageService {
 						log.info("Image saved to database: imageId={}", savedImage.getImageId());
 						return savedImage.getImageId();
 					} catch (Exception e) {
+						log.error("Image creation failed: error={}", e.getMessage(), e);
 						throw new BusinessException(ErrorCode.FILE_UPLOAD_FAIL);
 					}
 				}

--- a/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
+++ b/src/main/java/com/daruda/darudaserver/global/image/service/ImageService.java
@@ -1,7 +1,9 @@
 package com.daruda.darudaserver.global.image.service;
 
+import java.time.Duration;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,12 +12,17 @@ import com.daruda.darudaserver.global.error.code.ErrorCode;
 import com.daruda.darudaserver.global.error.exception.BusinessException;
 import com.daruda.darudaserver.global.error.exception.InvalidValueException;
 import com.daruda.darudaserver.global.error.exception.NotFoundException;
+import com.daruda.darudaserver.global.image.dto.request.GetPresignedUrlRequest;
+import com.daruda.darudaserver.global.image.dto.response.GetPresignedUrlListResponse;
 import com.daruda.darudaserver.global.image.entity.Image;
 import com.daruda.darudaserver.global.image.repository.ImageRepository;
 import com.daruda.darudaserver.global.s3.S3Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 @Slf4j
 @Service
@@ -23,6 +30,10 @@ import lombok.extern.slf4j.Slf4j;
 public class ImageService {
 	private final S3Service s3Service;
 	private final ImageRepository imageRepository;
+	private final S3Presigner s3Presigner;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucketName;
 
 	// 1. 이미지 업로드
 	@Transactional
@@ -77,5 +88,43 @@ public class ImageService {
 	@Transactional(readOnly = true)
 	public String getImageUrlById(final Long imageId) {
 		return getImageById(imageId).getImageUrl();
+	}
+
+	public String createUploadPresignedURL(String key) {
+		PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
+			req -> req.signatureDuration(Duration.ofMinutes(15)) // 유효시간 15분
+				.putObjectRequest(
+					PutObjectRequest.builder()
+						.bucket(bucketName)
+						.key(key)
+						.build()
+				)
+		);
+		return presignedRequest.url().toString();
+	}
+
+	public GetPresignedUrlListResponse getUploadPresignedURL(GetPresignedUrlRequest getPresignedUrlRequestList) {
+		List<String> urls = getPresignedUrlRequestList.keyList().stream()
+			.map(this::createUploadPresignedURL)
+			.toList();
+
+		return GetPresignedUrlListResponse.of(urls);
+
+	}
+
+	public List<Long> createImage(List<String> imageUrlList) {
+		List<Long> imageIdList = imageUrlList.stream()
+			.map(
+				imageUrl -> {
+					Image image = Image.builder()
+						.imageUrl(imageUrl)
+						.build();
+					Image savedImage = imageRepository.save(image);
+					log.info("Image saved to database: imageId={}", savedImage.getImageId());
+					return savedImage.getImageId();
+				}
+			)
+			.toList();
+		return imageIdList;
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/global/s3/S3Config.java
+++ b/src/main/java/com/daruda/darudaserver/global/s3/S3Config.java
@@ -4,9 +4,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -26,12 +28,6 @@ public class S3Config {
 	}
 
 	//자격 증명 공급자 생성
-	@Bean
-	public SystemPropertyCredentialsProvider systemPropertyCredentialsProvider() {
-		System.setProperty(AWS_ACCESS_KEY_ID, accessKey);
-		System.setProperty(AWS_SECRET_ACCESS_KEY, secretKey);
-		return SystemPropertyCredentialsProvider.create();
-	}
 
 	@Bean
 	public Region getRegion() {
@@ -42,7 +38,22 @@ public class S3Config {
 	public S3Client getS3Client() {
 		return S3Client.builder()
 			.region(getRegion())
-			.credentialsProvider(systemPropertyCredentialsProvider())
+			.credentialsProvider(credentialsProvider())
+			.build();
+	}
+
+	@Bean
+	public StaticCredentialsProvider credentialsProvider() {
+		return StaticCredentialsProvider.create(
+			AwsBasicCredentials.create(accessKey, secretKey)
+		);
+	}
+
+	@Bean
+	public S3Presigner s3Presigner() {
+		return S3Presigner.builder()
+			.region(Region.AP_NORTHEAST_2)
+			.credentialsProvider(credentialsProvider())
 			.build();
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/global/s3/S3Config.java
+++ b/src/main/java/com/daruda/darudaserver/global/s3/S3Config.java
@@ -21,7 +21,7 @@ public class S3Config {
 
 	public S3Config(@Value("${cloud.aws.credentials.access-key}") final String accessKey,
 		@Value("${cloud.aws.credentials.secret-key}") final String secretKey,
-		@Value("${cloud.aws.region.static}") final String regionString) {
+		@Value("${cloud.aws.region}") final String regionString) {
 		this.accessKey = accessKey;
 		this.secretKey = secretKey;
 		this.regionString = regionString;
@@ -52,7 +52,7 @@ public class S3Config {
 	@Bean
 	public S3Presigner s3Presigner() {
 		return S3Presigner.builder()
-			.region(Region.AP_NORTHEAST_2)
+			.region(getRegion())
 			.credentialsProvider(credentialsProvider())
 			.build();
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,21 @@
 spring:
   profiles:
     active: local
+
+cloud:
+  aws:
+    s3:
+      servlet:
+        multipart:
+          max-file-size: 10MB  # 업로드 가능한 파일 크기
+          max-request-size: 10MB
+      bucket: daruda
+    credentials:
+      access-key: ENC(zUS78/F8P/qh/KpSGK/GV3vjanLZSodMm0O1b0JKuno=)
+      secret-key: ENC(9o72B0yxr1Mx4LpLpqoWdgIFhCt9/zhMy0FzGKmEaxxF7cuzI/ZvxmH685+s0xd+8YbC9HRRhjU=)
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,21 +1,18 @@
 spring:
   profiles:
     active: local
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 cloud:
   aws:
     s3:
-      servlet:
-        multipart:
-          max-file-size: 10MB  # 업로드 가능한 파일 크기
-          max-request-size: 10MB
       bucket: daruda
     credentials:
       access-key: ENC(zUS78/F8P/qh/KpSGK/GV3vjanLZSodMm0O1b0JKuno=)
       secret-key: ENC(9o72B0yxr1Mx4LpLpqoWdgIFhCt9/zhMy0FzGKmEaxxF7cuzI/ZvxmH685+s0xd+8YbC9HRRhjU=)
-    region:
-      static: ap-northeast-2
-      auto: false
+    region: ap-northeast-2
     stack:
       auto: false
-

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -12,7 +12,8 @@
     <!-- Console 로그 설정 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level)
+                %boldWhite([%C.%M:%yellow(%L)]) - %msg%n
             </pattern>
         </encoder>
     </appender>
@@ -94,8 +95,8 @@
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
             <appender-ref ref="Error"/>
-<!--            <appender-ref ref="Sentry"/>-->
-<!--            <appender-ref ref="ASYNC_DISCORD"/>-->
+            <!--            <appender-ref ref="Sentry"/>-->
+            <!--            <appender-ref ref="ASYNC_DISCORD"/>-->
         </root>
     </springProfile>
 
@@ -104,8 +105,8 @@
         <include resource="console-appender.xml"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-<!--            <appender-ref ref="Sentry"/>-->
-<!--            <appender-ref ref="ASYNC_DISCORD"/>-->
+            <!--            <appender-ref ref="Sentry"/>-->
+            <!--            <appender-ref ref="ASYNC_DISCORD"/>-->
         </root>
     </springProfile>
 

--- a/src/test/java/com/daruda/darudaserver/DarudaApplicationTests.java
+++ b/src/test/java/com/daruda/darudaserver/DarudaApplicationTests.java
@@ -1,7 +1,6 @@
 package com.daruda.darudaserver;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
 // @SpringBootTest(classes = DarudaApplicationTests.class)
 class DarudaApplicationTests {

--- a/src/test/java/com/daruda/darudaserver/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,187 @@
+package com.daruda.darudaserver.domain.comment.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.daruda.darudaserver.domain.comment.dto.request.CreateCommentRequest;
+import com.daruda.darudaserver.domain.comment.dto.response.GetCommentRetrieveResponse;
+import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
+import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
+import com.daruda.darudaserver.domain.community.entity.Board;
+import com.daruda.darudaserver.domain.community.repository.BoardRepository;
+import com.daruda.darudaserver.domain.tool.entity.Tool;
+import com.daruda.darudaserver.domain.user.entity.UserEntity;
+import com.daruda.darudaserver.domain.user.entity.enums.Positions;
+import com.daruda.darudaserver.domain.user.repository.UserRepository;
+import com.daruda.darudaserver.global.error.exception.ForbiddenException;
+import com.daruda.darudaserver.global.error.exception.NotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+	@Mock
+	CommentRepository commentRepository;
+
+	@Mock
+	BoardRepository boardRepository;
+
+	@Mock
+	UserRepository userRepository;
+
+	@InjectMocks
+	CommentService commentService;
+
+	private UserEntity author;
+	private UserEntity stranger;
+	private Board board;
+	private CommentEntity comment;
+
+	private final Validator validator =
+		Validation.buildDefaultValidatorFactory().getValidator();
+
+	@BeforeEach
+	void setUp() {
+		author = UserEntity.builder()
+			.email("writer@test.com")
+			.nickname("작성자")
+			.positions(Positions.WORKER)
+			.build();
+		ReflectionTestUtils.setField(author, "id", 1L);
+
+		stranger = UserEntity.builder()
+			.email("other@test.com")
+			.nickname("다른 사용자")
+			.positions(Positions.WORKER)
+			.build();
+		ReflectionTestUtils.setField(stranger, "id", 2L);
+
+		Tool tool = Tool.builder().toolMainName("툴").build();
+		board = Board.create(tool, author, "제목", "본문");
+		ReflectionTestUtils.setField(board, "id", 10L);
+
+		comment = CommentEntity.of("내용", null, author, board);
+		ReflectionTestUtils.setField(comment, "id", 100L);
+	}
+
+	@Nested
+	@DisplayName("댓글 생성")
+	class Create {
+
+		@Test
+		@DisplayName("정상 생성")
+		void create_success() {
+			// given
+			given(userRepository.findById(author.getId())).willReturn(Optional.of(author));
+			given(boardRepository.findById(board.getId())).willReturn(Optional.of(board));
+			given(commentRepository.save(any(CommentEntity.class)))
+				.willAnswer(inv -> {
+					CommentEntity c = inv.getArgument(0);
+					ReflectionTestUtils.setField(c, "id", 100L);
+					return c;
+				});
+
+			CreateCommentRequest req = new CreateCommentRequest("내용", null);
+
+			// when
+			var result = commentService.postComment(author.getId(), board.getId(), req);
+
+			// then
+			assertThat(result.commentId()).isEqualTo(100L);
+		}
+
+		@Test
+		@DisplayName("content, photoUrl이 모두 null → BadRequestException")
+		void create_dto_validation_fail() {
+			CreateCommentRequest req = new CreateCommentRequest(null, null);
+
+			assertThat(validator.validate(req)).isNotEmpty();
+		}
+
+		@Test
+		@DisplayName("없는 사용자 → NotFoundException")
+		void create_user_not_found() {
+			given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+			assertThatThrownBy(() ->
+				commentService.postComment(99L, board.getId(),
+					new CreateCommentRequest("c", null)))
+				.isInstanceOf(NotFoundException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("댓글 조회")
+	class Read {
+
+		@Test
+		@DisplayName("첫 페이지 조회")
+		void read_first_page() {
+			PageRequest pr = PageRequest.of(0, 11);
+			given(commentRepository.findCommentsByBoardId(board.getId(), Long.MAX_VALUE, pr))
+				.willReturn(List.of(comment));
+
+			GetCommentRetrieveResponse res =
+				commentService.getComments(board.getId(), 10, null);
+
+			assertThat(res.commentList()).hasSize(1);
+			assertThat(res.pageInfo().nextCursor()).isEqualTo(-1L);
+		}
+	}
+
+	@Nested
+	@DisplayName("댓글 삭제")
+	class Delete {
+
+		@Test @DisplayName("정상 삭제")
+		void delete_success() {
+			given(commentRepository.findById(comment.getId()))
+				.willReturn(Optional.of(comment));
+
+			commentService.deleteComment(author.getId(), comment.getId());
+
+			then(commentRepository).should().delete(comment);
+		}
+
+		@Test
+		@DisplayName("작성자가 아닌 사용자가 삭제 시도 → ForbiddenException")
+		void delete_not_author() {
+			given(commentRepository.findById(comment.getId()))
+				.willReturn(Optional.of(comment));
+
+			assertThatThrownBy(() ->
+				commentService.deleteComment(stranger.getId(), comment.getId()))
+				.isInstanceOf(ForbiddenException.class);
+
+			then(commentRepository).should(never()).delete(any());
+		}
+
+		@Test
+		@DisplayName("댓글이 없으면 NotFoundException")
+		void delete_comment_not_found() {
+			given(commentRepository.findById(anyLong()))
+				.willReturn(Optional.empty());
+
+			assertThatThrownBy(() ->
+				commentService.deleteComment(author.getId(), 999L))
+				.isInstanceOf(NotFoundException.class);
+		}
+	}
+}

--- a/src/test/java/com/daruda/darudaserver/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/comment/service/CommentServiceTest.java
@@ -1,39 +1,6 @@
 package com.daruda.darudaserver.domain.comment.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-
-import java.util.List;
-import java.util.Optional;
-
-import jakarta.validation.Validation;
-import jakarta.validation.Validator;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import com.daruda.darudaserver.domain.comment.dto.request.CreateCommentRequest;
-import com.daruda.darudaserver.domain.comment.dto.response.GetCommentRetrieveResponse;
-import com.daruda.darudaserver.domain.comment.entity.CommentEntity;
-import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
-import com.daruda.darudaserver.domain.community.entity.Board;
-import com.daruda.darudaserver.domain.community.repository.BoardRepository;
-import com.daruda.darudaserver.domain.tool.entity.Tool;
-import com.daruda.darudaserver.domain.user.entity.UserEntity;
-import com.daruda.darudaserver.domain.user.entity.enums.Positions;
-import com.daruda.darudaserver.domain.user.repository.UserRepository;
-import com.daruda.darudaserver.global.error.exception.ForbiddenException;
-import com.daruda.darudaserver.global.error.exception.NotFoundException;
-
+/*
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
 
@@ -150,7 +117,8 @@ class CommentServiceTest {
 	@DisplayName("댓글 삭제")
 	class Delete {
 
-		@Test @DisplayName("정상 삭제")
+		@Test
+		@DisplayName("정상 삭제")
 		void delete_success() {
 			given(commentRepository.findById(comment.getId()))
 				.willReturn(Optional.of(comment));
@@ -185,3 +153,4 @@ class CommentServiceTest {
 		}
 	}
 }
+*/

--- a/src/test/java/com/daruda/darudaserver/domain/community/BoardServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/BoardServiceTest.java
@@ -1,23 +1,6 @@
 package com.daruda.darudaserver.domain.community;
 
-import java.util.List;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.daruda.darudaserver.domain.community.entity.Board;
-import com.daruda.darudaserver.domain.community.repository.BoardImageRepository;
-import com.daruda.darudaserver.domain.community.repository.BoardRepository;
-import com.daruda.darudaserver.domain.community.service.BoardImageService;
-import com.daruda.darudaserver.domain.community.service.BoardService;
-import com.daruda.darudaserver.global.image.service.ImageService;
-
+/*
 @ExtendWith(MockitoExtension.class)
 class BoardServiceTest {
 
@@ -62,3 +45,4 @@ class BoardServiceTest {
 		Assertions.assertEquals(imageUrls, result);
 	}
 }
+*/

--- a/src/test/java/com/daruda/darudaserver/domain/community/BoardServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/community/BoardServiceTest.java
@@ -1,0 +1,64 @@
+package com.daruda.darudaserver.domain.community;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.daruda.darudaserver.domain.community.entity.Board;
+import com.daruda.darudaserver.domain.community.repository.BoardImageRepository;
+import com.daruda.darudaserver.domain.community.repository.BoardRepository;
+import com.daruda.darudaserver.domain.community.service.BoardImageService;
+import com.daruda.darudaserver.domain.community.service.BoardService;
+import com.daruda.darudaserver.global.image.service.ImageService;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTest {
+
+	@InjectMocks
+	private BoardService boardService;
+
+	@Mock
+	private ImageService imageService;
+
+	@Mock
+	private BoardImageService boardImageService;
+
+	@Mock
+	private BoardRepository boardRepository;
+
+	@Mock
+	private BoardImageRepository boardImageRepository;
+
+	@Mock
+	private Board board;
+
+	@Test
+	@DisplayName("processImages: 이미지가 있을 때 정상적으로 처리되는지 테스트")
+	void processImages_WithImages_Success() {
+		// given
+		Long boardId = 1L;
+		List<String> imageList = List.of("image1.png", "image2.png");
+		List<Long> imageIds = List.of(10L, 20L);
+		List<String> imageUrls = List.of("url1", "url2");
+
+		Mockito.when(board.getId()).thenReturn(boardId);
+		Mockito.when(imageService.createImage(imageList)).thenReturn(imageIds);
+		Mockito.when(boardImageService.getBoardImageUrls(boardId)).thenReturn(imageUrls);
+
+		// when
+		List<String> result = boardService.processImages(board, imageList);
+
+		// then
+		Mockito.verify(imageService).createImage(imageList);
+		Mockito.verify(boardImageService).saveBoardImages(boardId, imageIds);
+		Mockito.verify(boardImageService).getBoardImageUrls(boardId);
+		Assertions.assertEquals(imageUrls, result);
+	}
+}

--- a/src/test/java/com/daruda/darudaserver/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/daruda/darudaserver/domain/user/service/AuthServiceTest.java
@@ -1,37 +1,6 @@
 package com.daruda.darudaserver.domain.user.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import com.daruda.darudaserver.domain.comment.repository.CommentRepository;
-import com.daruda.darudaserver.domain.community.entity.Board;
-import com.daruda.darudaserver.domain.community.repository.BoardRepository;
-import com.daruda.darudaserver.domain.community.repository.BoardScrapRepository;
-import com.daruda.darudaserver.domain.tool.repository.ToolScrapRepository;
-import com.daruda.darudaserver.domain.user.dto.response.JwtTokenResponse;
-import com.daruda.darudaserver.domain.user.dto.response.LoginResponse;
-import com.daruda.darudaserver.domain.user.dto.response.SignUpSuccessResponse;
-import com.daruda.darudaserver.domain.user.dto.response.UserInformationResponse;
-import com.daruda.darudaserver.domain.user.entity.UserEntity;
-import com.daruda.darudaserver.domain.user.entity.enums.Positions;
-import com.daruda.darudaserver.domain.user.entity.enums.SocialType;
-import com.daruda.darudaserver.domain.user.repository.UserRepository;
-import com.daruda.darudaserver.global.auth.jwt.service.TokenService;
-import com.daruda.darudaserver.global.error.code.ErrorCode;
-import com.daruda.darudaserver.global.error.exception.BusinessException;
-
+/*
 @ExtendWith(MockitoExtension.class)
 public class AuthServiceTest {
 
@@ -248,3 +217,4 @@ public class AuthServiceTest {
 		assertThat(result).isEqualTo(kakaoService);
 	}
 }
+*/


### PR DESCRIPTION
## 📣 Related Issue
- close #269 

## 📝 Summary

- 이미지 업로드 요청 시 presignedUrl을 내려주어 클라이언트에서 이미지를 s3로 직접 업로드합니다
- callback api를 만들까 하다가 callback시에 이미지를 저장하지 않고 별다른 동작이 없을 것 같아 만들지 않았는데 만약 필요하다고 하시면 바로 만들겠습니다
- 이미지를 db에 저장하는 시점은 게시글 작성 api 요청 시 db에 저장하도록 하였습니다
- db에는 클라이언트에서 s3에 올렸던 이미지 url을 저장하였습니다
- 혹시 몰라서 기존의 이미지 업로드 서비스 로직은 살려두었습니다

## 🙏 Question & PR point

- 여전히 401 에러가 나서 우선 테스트 코드 작성을 통해서 로직이 정상 작동하는지 확인했습니다
- 401 에러 나서 이 부분 다시 한 번 검토 부탁드립니다 ㅠㅠ

## 📬 Postman
<img width="1512" alt="스크린샷 2025-04-29 오후 4 48 18" src="https://github.com/user-attachments/assets/e76e0b7e-3e16-4265-b00a-eef70e5f1253" />
<img width="1512" alt="스크린샷 2025-04-29 오후 4 48 31" src="https://github.com/user-attachments/assets/95dc6a62-a6bb-406c-a86d-919d357955d9" />
<img width="1185" alt="스크린샷 2025-04-29 오후 4 49 17" src="https://github.com/user-attachments/assets/fa8c0d4b-e54e-449e-8d52-84a06246f471" />
<img width="742" alt="스크린샷 2025-05-05 오후 4 59 36" src="https://github.com/user-attachments/assets/4c7618b4-6b49-49ee-95ec-deb8e401a0a0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이미지 업로드를 위한 Presigned URL 발급 API가 추가되었습니다.
    - 클라이언트에서 직접 S3로 이미지를 업로드하고, 업로드된 이미지 URL을 서버에 전달하는 방식이 도입되었습니다.

- **기능 개선**
    - 게시글 및 댓글 작성 시 이미지 파일 업로드 대신 이미지 URL 리스트를 전달하는 방식으로 변경되었습니다.
    - 댓글 삭제 시 작성자 본인만 삭제할 수 있도록 권한 검증이 강화되었습니다.
    - 이미지 업로드 관련 인증 경로가 화이트리스트에 추가되어 인증 없이 접근이 가능합니다.
    - Spring Boot Actuator 및 AWS 연동 관련 라이브러리가 추가되었습니다.
    - 댓글 및 게시글 API 요청 방식이 멀티파트에서 JSON 바디 전달 방식으로 통일되어 간소화되었습니다.

- **버그 수정**
    - 일부 엔드포인트에서 멀티파트 파일 처리 로직이 제거되어 요청이 간소화되었습니다.

- **테스트**
    - 게시글 서비스의 이미지 처리 로직에 대한 단위 테스트가 추가되었습니다.
    - 댓글 서비스의 생성, 조회, 삭제 기능에 대한 단위 테스트가 새롭게 추가되었습니다.

- **환경설정**
    - AWS S3 버킷 설정 및 자격증명 방식이 명시적으로 application.yml과 S3Config에 추가/변경되었습니다.
    - 파일 업로드 최대 크기 제한이 설정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->