### PR TITLE
Fix/#304 ElasticSearch 관련 오류 수정

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/search/document/ToolDocument.java
+++ b/src/main/java/com/daruda/darudaserver/domain/search/document/ToolDocument.java
@@ -65,6 +65,9 @@ public class ToolDocument {
 	@Field(type = FieldType.Integer)
 	private int popular;
 
+	@Field(type = FieldType.Keyword)
+	private String toolLogo;
+
 	public static ToolDocument from(Tool tool) {
 		return ToolDocument.builder()
 			.id(tool.getToolId().toString())
@@ -81,6 +84,7 @@ public class ToolDocument {
 			.fontColor(tool.isFontColor())
 			.viewCount(tool.getViewCount())
 			.popular(tool.getPopular())
+			.toolLogo(tool.getToolLogo())
 			.build();
 	}
 }

--- a/src/main/java/com/daruda/darudaserver/domain/search/dto/response/ToolSearchResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/search/dto/response/ToolSearchResponse.java
@@ -19,7 +19,7 @@ public record ToolSearchResponse(
 		return new ToolSearchResponse(
 			document.getId(),
 			document.getToolMainName(),
-			document.getToolLink(),
+			document.getToolLogo(),
 			document.getDescription(),
 			document.getLicense(),
 			keywords,

--- a/src/main/java/com/daruda/darudaserver/domain/search/service/BoardSearchService.java
+++ b/src/main/java/com/daruda/darudaserver/domain/search/service/BoardSearchService.java
@@ -81,7 +81,10 @@ public class BoardSearchService {
 		NativeQuery query = NativeQuery.builder()
 			.withQuery(finalQuery)
 			.withPageable(PageRequest.of(0, size + 1))  // size + 1로 hasNext 확인
-			.withSort(Sort.by(Sort.Order.desc("updatedAt")))
+			.withSort(Sort.by(
+				Sort.Order.desc("updatedAt"),
+				Sort.Order.desc("id")
+			))
 			.build();
 
 		SearchHits<BoardDocument> hits = elasticsearchTemplate.search(query, BoardDocument.class);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #304 

## 📝 Summary

- Board에서 같은 값만 내려가는 것 수정
- ToolLogo안 나옴 수정

## 🙏 Question & PR point

- 정렬 기준을 updatedAt으로만 하지 않고 id기반으로 같이 해주니 다른 값이 내려오는 것을 확인하였습니다

## 📬 Postman

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/af245894-cd8b-4947-b0ff-f94084ce2ee5" />
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/bc032880-9849-412a-bfe2-99d9e8d832bd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 툴 검색 결과에 툴 로고 정보가 추가되었습니다.

* **버그 수정**
  * 툴 검색 결과에서 툴 로고가 올바르게 표시되도록 정보 매핑이 수정되었습니다.

* **기타**
  * 게시글 검색 시 정렬 기준에 id 내림차순이 추가되어, 동일한 수정일의 게시글이 더 일관되게 정렬됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->