### PR TITLE
[Fix] QA애서 발생한 수정사항 반영

### DIFF
--- a/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/GetCommentResponse.java
+++ b/src/main/java/com/daruda/darudaserver/domain/comment/dto/response/GetCommentResponse.java
@@ -2,6 +2,8 @@ package com.daruda.darudaserver.domain.comment.dto.response;
 
 import java.sql.Timestamp;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import lombok.Builder;
 
 @Builder
@@ -10,6 +12,8 @@ public record GetCommentResponse(
 	Long commentId,
 	String nickname,
 	String image,
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
 	Timestamp updatedAt
 ) {
 

--- a/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/community/controller/BoardController.java
@@ -4,7 +4,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,7 +52,7 @@ public class BoardController {
 		@Parameter(description = "board Id", example = "1")
 		@PathVariable(name = "board-id") final Long boardId,
 		@Parameter(description = "수정할 게시글")
-		@ModelAttribute @Valid final BoardCreateAndUpdateReq boardCreateAndUpdateReq) {
+		@RequestBody @Valid final BoardCreateAndUpdateReq boardCreateAndUpdateReq) {
 		BoardRes boardRes = boardService.updateBoard(userId, boardId, boardCreateAndUpdateReq);
 		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(boardRes, SuccessCode.SUCCESS_UPDATE));
 	}

--- a/src/main/java/com/daruda/darudaserver/domain/user/controller/AuthController.java
+++ b/src/main/java/com/daruda/darudaserver/domain/user/controller/AuthController.java
@@ -110,8 +110,11 @@ public class AuthController {
 	@PostMapping("/logout")
 	@Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
 	public ResponseEntity<ApiResponse<Long>> logout(
-		@AuthenticationPrincipal Long userId
+		@AuthenticationPrincipal Long userId,
+		HttpServletResponse httpServletResponse
 	) {
+		cookieProvider.deleteTokenCookies(httpServletResponse);
+
 		return ResponseEntity.ok(ApiResponse.ofSuccessWithData(authService.logout(userId), SuccessCode.SUCCESS_LOGOUT));
 	}
 
@@ -133,8 +136,10 @@ public class AuthController {
 	@DeleteMapping("/withdraw")
 	@Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
 	public ResponseEntity<ApiResponse<Void>> withdraw(
-		@AuthenticationPrincipal Long userId
+		@AuthenticationPrincipal Long userId,
+		HttpServletResponse httpServletResponse
 	) {
+		cookieProvider.deleteTokenCookies(httpServletResponse);
 		authService.withdraw(userId);
 		return ResponseEntity.ok(ApiResponse.ofSuccess(SuccessCode.SUCCESS_WITHDRAW));
 	}

--- a/src/main/java/com/daruda/darudaserver/global/auth/cookie/CookieProvider.java
+++ b/src/main/java/com/daruda/darudaserver/global/auth/cookie/CookieProvider.java
@@ -28,6 +28,14 @@ public class CookieProvider {
 		response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 	}
 
+	public void deleteTokenCookies(HttpServletResponse response) {
+		ResponseCookie accessTokenCookie = createTokenCookie(ACCESS_TOKEN, "", 0);
+		ResponseCookie refreshTokenCookie = createTokenCookie(REFRESH_TOKEN, "", 0);
+
+		response.addHeader("Set-Cookie", accessTokenCookie.toString());
+		response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+	}
+
 	private ResponseCookie createTokenCookie(String name, String value, int maxAge) {
 		return ResponseCookie.from(name, value)
 			.maxAge(maxAge)


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #306

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- [x] 로그아웃이나 회원 탈퇴 시 쿠키가 삭제되지 않는 오류 수정
- [x] 게시글 수정 API 요청 데이터를 쿼리 파라미터가 아닌 Json으로 전송하도록 수정
- [x] 댓글 조회 시 `updateAt`필드가 timestamp로 반환되는 오류 수정

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

### 로그아웃이나 회원 탈퇴 시 쿠키가 삭제되지 않는 오류 수정
<img width="1728" height="998" alt="image" src="https://github.com/user-attachments/assets/566a49e9-852e-4c45-b1f9-385ac0295658" />


### 게시글 수정 API 요청 데이터를 쿼리 파라미터가 아닌 Json으로 전송하도록 수정
<img width="2840" height="4368" alt="image" src="https://github.com/user-attachments/assets/ec93c877-cc41-42a3-8975-8f860c1a7f62" />

### 댓글 조회 시 `updateAt`필드가 timestamp로 반환되는 오류 수정
<img width="2840" height="4073" alt="image" src="https://github.com/user-attachments/assets/51281d6a-93f5-45c7-9f6e-ed4743164e9e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 댓글 조회 시 updatedAt 날짜가 "yyyy.MM.dd" 형식(Asia/Seoul 시간대)으로 표시됩니다.
  * 게시글 수정 요청 시 JSON 형식의 본문 데이터로 요청을 받도록 변경되었습니다.
  * 로그아웃 및 회원 탈퇴 시 토큰 쿠키가 명확히 삭제되어 보안이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->